### PR TITLE
Add inline block to Pantheon logo image in admin bar item

### DIFF
--- a/inc/class-toolbar.php
+++ b/inc/class-toolbar.php
@@ -188,6 +188,7 @@ EOT;
 		?>
 		<style>
 			#wpadminbar li#wp-admin-bar-pantheon-hud > .ab-item img {
+				display:inline-block;
 				height:32px;
 				width:32px;
 				vertical-align:middle;


### PR DESCRIPTION
The Pantheon logo pushes the environment label out of the admin bar item if the theme has this fairly common bit of CSS: 

```css
img {
  display: block;
}
```

![CleanShot 2024-11-12 at 17 10 50](https://github.com/user-attachments/assets/f7c7ddbb-7979-4d3f-b169-f6322acf3059)

Adding `display: inline-block;` to the icon fixes it: 

![CleanShot 2024-11-12 at 17 13 29](https://github.com/user-attachments/assets/3d641110-cc69-44cd-926a-1b592685c106)
